### PR TITLE
fix(AI Usage): 修复 Codex 附加额度、Spark 与套餐识别

### DIFF
--- a/AI Usage/providers/codex/api.ts
+++ b/AI Usage/providers/codex/api.ts
@@ -89,7 +89,7 @@ function slug(value: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 }
-function isOrdinaryWindow(window: LimitWindow): boolean {
+export function isOrdinaryWindow(window: LimitWindow): boolean {
   return window.id.startsWith("codex:") || window.id.startsWith("direct:");
 }
 function sameWindow(left: LimitWindow, right: LimitWindow): boolean {
@@ -172,6 +172,7 @@ function extractWindows(payload: Record<string, unknown>): LimitWindow[] {
         const limitName = toStringValue(
           obj?.limit_name ?? obj?.metered_feature,
         );
+        const isSpark = Boolean(limitName && /spark/i.test(limitName));
         const featureId =
           slug(toStringValue(obj?.metered_feature) || limitName || "") ||
           `unknown-${i}`;
@@ -180,7 +181,7 @@ function extractWindows(payload: Record<string, unknown>): LimitWindow[] {
             rate,
             `extra:${featureId}`,
             limitName || "",
-            limitName || "Codex 附加限额",
+            isSpark ? "Codex Spark" : limitName || "Codex 附加限额",
           ),
         );
       }
@@ -419,7 +420,11 @@ export function pickFocusWindow(
   snapshot: UsageSnapshot,
   focus: "weekly" | "five_hour" | "monthly" = "weekly",
 ): LimitWindow | null {
-  return snapshot.windows.find((w) => w.name === focus) || null;
+  return (
+    snapshot.windows.find(
+      (window) => isOrdinaryWindow(window) && window.name === focus,
+    ) || null
+  );
 }
 function recent(cache: UsageSnapshot | null): boolean {
   if (!cache?.fetchedAt) return false;
@@ -552,9 +557,18 @@ export async function fetchUsage(options?: {
         : (cache?.resetCreditExpirations ?? []);
     const snapshot: UsageSnapshot = {
       windows,
-      fiveHour: windows.find((w) => w.name === "five_hour") || null,
-      weekly: windows.find((w) => w.name === "weekly") || null,
-      monthly: windows.find((w) => w.name === "monthly") || null,
+      fiveHour:
+        windows.find(
+          (window) => isOrdinaryWindow(window) && window.name === "five_hour",
+        ) || null,
+      weekly:
+        windows.find(
+          (window) => isOrdinaryWindow(window) && window.name === "weekly",
+        ) || null,
+      monthly:
+        windows.find(
+          (window) => isOrdinaryWindow(window) && window.name === "monthly",
+        ) || null,
       planType: rawPlanType,
       planLabel: planLabel(payload),
       creditStatus,

--- a/AI Usage/providers/codex/api.ts
+++ b/AI Usage/providers/codex/api.ts
@@ -82,6 +82,23 @@ function label(name: LimitWindowName, seconds: number | null): string {
   if (seconds && seconds >= 86400) return `${Math.round(seconds / 86400)} 天`;
   return codexWindowTitle("unknown");
 }
+function slug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+function isOrdinaryWindow(window: LimitWindow): boolean {
+  return window.id.startsWith("codex:") || window.id.startsWith("direct:");
+}
+function sameWindow(left: LimitWindow, right: LimitWindow): boolean {
+  return (
+    left.name === right.name &&
+    left.resetAtMs === right.resetAtMs &&
+    left.usedPercent === right.usedPercent
+  );
+}
 function parseWindow(
   value: unknown,
   id: string,
@@ -115,6 +132,7 @@ function collectFromRateLimit(
   rate: Record<string, unknown>,
   prefix: string,
   hint = "",
+  labelPrefix = "",
 ): LimitWindow[] {
   const out: LimitWindow[] = [];
   const keys = [
@@ -132,7 +150,10 @@ function collectFromRateLimit(
     if (!value || seen.has(value)) continue;
     seen.add(value);
     const parsed = parseWindow(value, `${prefix}:${key}`, `${hint} ${key}`);
-    if (parsed) out.push(parsed);
+    if (parsed) {
+      if (labelPrefix) parsed.label = `${labelPrefix} ${parsed.label}`;
+      if (!out.some((window) => sameWindow(window, parsed))) out.push(parsed);
+    }
   }
   return out;
 }
@@ -147,14 +168,22 @@ function extractWindows(payload: Record<string, unknown>): LimitWindow[] {
     additional.forEach((item, i) => {
       const obj = asObject(item);
       const rate = asObject(obj?.rate_limit) || obj;
-      if (rate)
+      if (rate) {
+        const limitName = toStringValue(
+          obj?.limit_name ?? obj?.metered_feature,
+        );
+        const featureId =
+          slug(toStringValue(obj?.metered_feature) || limitName || "") ||
+          `unknown-${i}`;
         out.push(
           ...collectFromRateLimit(
             rate,
-            `extra${i}`,
-            String(obj?.limit_name || obj?.metered_feature || ""),
+            `extra:${featureId}`,
+            limitName || "",
+            limitName || "Codex 附加限额",
           ),
         );
+      }
     });
   }
   const direct: Array<[string, LimitWindowName]> = [
@@ -164,23 +193,26 @@ function extractWindows(payload: Record<string, unknown>): LimitWindow[] {
   ];
   for (const [key, name] of direct) {
     const parsed = parseWindow(payload[key], `direct:${key}`, key);
-    if (parsed && !out.some((x) => x.name === name)) out.push(parsed);
+    if (
+      parsed &&
+      !out.some((window) => isOrdinaryWindow(window) && window.name === name)
+    ) {
+      out.push(parsed);
+    }
   }
   const unique: LimitWindow[] = [];
   for (const w of out) {
-    if (
-      !unique.some(
-        (x) =>
-          x.name === w.name &&
-          x.resetAtMs === w.resetAtMs &&
-          x.usedPercent === w.usedPercent,
-      )
-    )
-      unique.push(w);
+    if (!unique.some((x) => x.id === w.id)) unique.push(w);
   }
-  return unique.sort(
-    (a, b) => (a.windowSeconds || 1e20) - (b.windowSeconds || 1e20),
-  );
+  return unique.sort((a, b) => {
+    const sourceOrder =
+      Number(!isOrdinaryWindow(a)) - Number(!isOrdinaryWindow(b));
+    return (
+      sourceOrder ||
+      (a.windowSeconds || 1e20) - (b.windowSeconds || 1e20) ||
+      a.id.localeCompare(b.id)
+    );
+  });
 }
 function planLabel(payload: Record<string, unknown>): string | null {
   const raw = toStringValue(payload.plan_type)?.toLowerCase();

--- a/AI Usage/providers/codex/api.ts
+++ b/AI Usage/providers/codex/api.ts
@@ -2,6 +2,7 @@ import { fetch } from "scripting";
 import {
   getProfileAccountId,
   getProfileAccessToken,
+  getProfileIdToken,
   resolveProfile,
 } from "./accounts";
 import { refreshOAuthToken } from "./oauth";
@@ -215,16 +216,19 @@ function extractWindows(payload: Record<string, unknown>): LimitWindow[] {
     );
   });
 }
-function planLabel(payload: Record<string, unknown>): string | null {
-  const raw = toStringValue(payload.plan_type)?.toLowerCase();
+function planLabel(rawPlanType: string | null): string | null {
+  const raw = rawPlanType?.toLowerCase().trim() || null;
   if (!raw) return null;
   const labels: Record<string, string> = {
     guest: "Guest",
     free: "Free",
     go: "Go",
     plus: "Plus",
-    pro: "Pro",
-    prolite: "Pro Lite",
+    // ChatGPT Pro：$100=5× → prolite；$200=20× → pro
+    prolite: "Pro 5X",
+    pro: "Pro 20X",
+    chatgptpro: "Pro 20X",
+    chatgpt_pro: "Pro 20X",
     free_workspace: "Free Workspace",
     team: "Team",
     self_serve_business_prolite: "Business Pro Lite",
@@ -244,6 +248,45 @@ function planLabel(payload: Record<string, unknown>): string | null {
   return (
     labels[raw] ||
     raw.replace(/(^|_)(\w)/g, (_, __, c) => ` ${c.toUpperCase()}`).trim()
+  );
+}
+
+/**
+ * 从 JWT 读取 chatgpt_plan_type。
+ * 官方 Codex 从 id_token 的 https://api.openai.com/auth 解析；access_token 仅作次级回退。
+ */
+function planTypeFromJwt(token: string | null): string | null {
+  if (!token) return null;
+  try {
+    let raw = token.split(".")[1]?.replace(/-/g, "+").replace(/_/g, "/");
+    if (!raw) return null;
+    while (raw.length % 4) raw += "=";
+    const json = decodeURIComponent(
+      Array.from(atob(raw))
+        .map((c) => "%" + c.charCodeAt(0).toString(16).padStart(2, "0"))
+        .join(""),
+    );
+    const payload = asObject(JSON.parse(json));
+    if (!payload) return null;
+    const auth = asObject(payload["https://api.openai.com/auth"]);
+    return (
+      toStringValue(auth?.chatgpt_plan_type) ||
+      toStringValue(payload.chatgpt_plan_type) ||
+      toStringValue(auth?.plan_type)
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** usage 缺 plan_type 时：id_token → access_token。 */
+function planTypeFromStoredTokens(
+  profileId: string,
+  accessToken: string | null,
+): string | null {
+  return (
+    planTypeFromJwt(getProfileIdToken(profileId)) ||
+    planTypeFromJwt(accessToken)
   );
 }
 function parseCreditStatus(
@@ -537,7 +580,8 @@ export async function fetchUsage(options?: {
       };
     }
     const rawPlanType =
-      typeof payload.plan_type === "string" ? payload.plan_type : null;
+      toStringValue(payload.plan_type) ||
+      planTypeFromStoredTokens(profile.id, token);
     const creditStatus = parseCreditStatus(payload);
     const spendControl = parseSpendControl(payload);
     const status = rateLimitStatus(payload);
@@ -555,6 +599,8 @@ export async function fetchUsage(options?: {
       detailedResetCredits != null || embeddedResetCredits.count != null
         ? liveResetExpirations
         : (cache?.resetCreditExpirations ?? []);
+    const resolvedPlanLabel =
+      planLabel(rawPlanType) || cache?.planLabel || cache?.planType || null;
     const snapshot: UsageSnapshot = {
       windows,
       fiveHour:
@@ -570,7 +616,7 @@ export async function fetchUsage(options?: {
           (window) => isOrdinaryWindow(window) && window.name === "monthly",
         ) || null,
       planType: rawPlanType,
-      planLabel: planLabel(payload),
+      planLabel: resolvedPlanLabel,
       creditStatus,
       spendControl,
       rateLimitAllowed: status.allowed,

--- a/AI Usage/providers/codex/normalize.ts
+++ b/AI Usage/providers/codex/normalize.ts
@@ -7,6 +7,10 @@ import {
   type NormalizedUsageSnapshot,
 } from "../../services/usage-model";
 
+function isOrdinaryWindow(window: { id: string }): boolean {
+  return window.id.startsWith("codex:") || window.id.startsWith("direct:");
+}
+
 export function normalizeUsageSnapshot(
   snapshot: UsageSnapshot,
 ): NormalizedUsageSnapshot {
@@ -20,9 +24,9 @@ export function normalizeUsageSnapshot(
       .map((window) => ({
         ...window,
         label:
-          window.name === "unknown"
-            ? window.label
-            : codexWindowTitle(window.name),
+          isOrdinaryWindow(window) && window.name !== "unknown"
+            ? codexWindowTitle(window.name)
+            : window.label,
       }))
       .map(toUsageWindowView)
       .filter(isUsageWindowView),

--- a/AI Usage/widget/MediumQuotaViews.tsx
+++ b/AI Usage/widget/MediumQuotaViews.tsx
@@ -132,6 +132,7 @@ export function SingleQuotaMediumView(props: {
   fetchedText: string;
   resetText: string;
   optionalMeta: MediumOptionalMeta;
+  additionalText?: string;
   errorText?: string;
 }) {
   const contentWidth = Math.max(180, props.width - 40);
@@ -271,6 +272,25 @@ export function SingleQuotaMediumView(props: {
           alignment="trailing"
         />
       </HStack>
+      {props.additionalText ? (
+        <HStack
+          frame={{
+            maxWidth: "infinity",
+            maxHeight: "infinity",
+            alignment: "bottomLeading",
+          }}
+          padding={{ horizontal: 20, bottom: props.errorText ? 13 : 2 }}
+        >
+          <Text
+            font={8}
+            foregroundStyle={C.secondary}
+            lineLimit={1}
+            minScaleFactor={0.55}
+          >
+            {props.additionalText}
+          </Text>
+        </HStack>
+      ) : null}
       {props.errorText ? (
         <HStack
           frame={{
@@ -420,6 +440,7 @@ export function DualQuotaMediumView(props: {
   first: MediumQuotaWindow;
   second: MediumQuotaWindow;
   secondOptionalMeta?: MediumOptionalMeta;
+  additionalText?: string;
   errorText?: string;
 }) {
   const contentWidth = Math.max(220, props.width - 40);
@@ -463,6 +484,25 @@ export function DualQuotaMediumView(props: {
         top={96}
         optionalMeta={props.secondOptionalMeta}
       />
+      {props.additionalText ? (
+        <HStack
+          frame={{
+            maxWidth: "infinity",
+            maxHeight: "infinity",
+            alignment: "bottomLeading",
+          }}
+          padding={{ horizontal: 20, bottom: props.errorText ? 13 : 2 }}
+        >
+          <Text
+            font={8}
+            foregroundStyle={C.secondary}
+            lineLimit={1}
+            minScaleFactor={0.55}
+          >
+            {props.additionalText}
+          </Text>
+        </HStack>
+      ) : null}
       {props.errorText ? (
         <HStack
           frame={{

--- a/AI Usage/widget/SmallQuotaViews.tsx
+++ b/AI Usage/widget/SmallQuotaViews.tsx
@@ -145,6 +145,7 @@ export function SingleQuotaSmallView(props: {
   fetchedText: string;
   resetText: string;
   optionalMeta: SmallOptionalMeta;
+  additionalText?: string;
 }) {
   const contentWidth = Math.max(90, props.width - 24);
   const verticalOffset = props.optionalMeta ? 0 : 6;
@@ -270,6 +271,26 @@ export function SingleQuotaSmallView(props: {
           width={contentWidth}
         />
       </VStack>
+      {props.additionalText ? (
+        <HStack
+          frame={{
+            maxWidth: "infinity",
+            maxHeight: "infinity",
+            alignment: "bottomLeading",
+          }}
+          padding={{ horizontal: 12, bottom: 1 }}
+        >
+          <Text
+            font={7}
+            fontWeight="medium"
+            foregroundStyle={C.secondary}
+            lineLimit={1}
+            minScaleFactor={0.5}
+          >
+            {props.additionalText}
+          </Text>
+        </HStack>
+      ) : null}
     </ZStack>
   );
 }
@@ -387,6 +408,7 @@ export function DualQuotaSmallView(props: {
   first: SmallQuotaWindow;
   second: SmallQuotaWindow;
   fetchedText: string;
+  additionalText?: string;
 }) {
   const contentWidth = Math.max(90, props.width - 24);
   const verticalOffset = 2 + Math.max(0, (displayHeight() - 158) / 2);
@@ -452,6 +474,26 @@ export function DualQuotaSmallView(props: {
           width={contentWidth}
         />
       </HStack>
+      {props.additionalText ? (
+        <HStack
+          frame={{
+            maxWidth: "infinity",
+            maxHeight: "infinity",
+            alignment: "bottomLeading",
+          }}
+          padding={{ horizontal: 12, bottom: 1 }}
+        >
+          <Text
+            font={7}
+            fontWeight="medium"
+            foregroundStyle={C.secondary}
+            lineLimit={1}
+            minScaleFactor={0.5}
+          >
+            {props.additionalText}
+          </Text>
+        </HStack>
+      ) : null}
     </ZStack>
   );
 }

--- a/AI Usage/widget/codex/DetailWidgetView.tsx
+++ b/AI Usage/widget/codex/DetailWidgetView.tsx
@@ -1,5 +1,8 @@
 import { Widget } from "scripting";
-import { pickFocusWindow } from "../../providers/codex/api";
+import {
+  isOrdinaryWindow,
+  pickFocusWindow,
+} from "../../providers/codex/api";
 import {
   formatPercent,
   formatResetDate,
@@ -34,7 +37,18 @@ type Model = {
   live: boolean;
   detail: string;
   hasResetCredits: boolean;
+  additionalText: string | null;
 };
+function additionalQuotaText(snapshot: UsageSnapshot | null): string | null {
+  const windows = snapshot?.windows.filter((window) => !isOrdinaryWindow(window));
+  if (!windows?.length) return null;
+  return windows
+    .map(
+      (window) =>
+        `${window.label} · 剩余 ${formatPercent(window.remainingPercent)}`,
+    )
+    .join(" / ");
+}
 function modelFor(result: UsageResult, focusName: Props["focusWindow"]): Model {
   const snapshot = result.ok ? result.snapshot : result.cache || null;
   const focus = snapshot ? pickFocusWindow(snapshot, focusName) : null;
@@ -60,6 +74,7 @@ function modelFor(result: UsageResult, focusName: Props["focusWindow"]): Model {
     live: result.ok,
     detail: result.ok ? "" : result.error.message,
     hasResetCredits: snapshot?.resetCreditsAvailable != null,
+    additionalText: additionalQuotaText(snapshot),
   };
 }
 function isSmall(family: string): boolean {
@@ -98,6 +113,7 @@ export function DetailWidgetView({ result, family, focusWindow }: Props) {
         remainingText={formatPercent(model.focus?.remainingPercent)}
         fetchedText={formatSmallDate(model.snapshot?.fetchedAt)}
         resetText={formatSmallDate(model.focus?.resetAt)}
+        additionalText={model.additionalText || undefined}
         optionalMeta={
           model.hasResetCredits
             ? {
@@ -123,6 +139,7 @@ export function DetailWidgetView({ result, family, focusWindow }: Props) {
       remainingText={model.main}
       fetchedText={model.fetched}
       resetText={formatResetDate(model.focus?.resetAt)}
+      additionalText={model.additionalText || undefined}
       optionalMeta={
         model.hasResetCredits
           ? { label: model.resetLabel, value: model.resetExpiration }

--- a/AI Usage/widget/codex/OverviewWidgetView.tsx
+++ b/AI Usage/widget/codex/OverviewWidgetView.tsx
@@ -30,7 +30,21 @@ type Model = {
   live: boolean;
   detail: string;
   hasResetCredits: boolean;
+  additionalText: string | null;
 };
+function isOrdinaryWindow(window: { id: string }): boolean {
+  return window.id.startsWith("codex:") || window.id.startsWith("direct:");
+}
+function additionalQuotaText(snapshot: UsageSnapshot | null): string | null {
+  const windows = snapshot?.windows.filter((window) => !isOrdinaryWindow(window));
+  if (!windows?.length) return null;
+  return windows
+    .map(
+      (window) =>
+        `${window.label} · 剩余 ${formatPercent(window.remainingPercent)}`,
+    )
+    .join(" / ");
+}
 function modelFor(result: UsageResult): Model {
   const snapshot = result.ok ? result.snapshot : result.cache || null;
   const resets = resetCreditsSummary(
@@ -40,13 +54,19 @@ function modelFor(result: UsageResult): Model {
   return {
     snapshot,
     fiveHour:
-      snapshot?.fiveHour ||
-      snapshot?.windows.find((w) => w.name === "five_hour") ||
-      null,
+      snapshot?.fiveHour && isOrdinaryWindow(snapshot.fiveHour)
+        ? snapshot.fiveHour
+        : snapshot?.windows.find(
+            (window) =>
+              isOrdinaryWindow(window) && window.name === "five_hour",
+          ) || null,
     weekly:
-      snapshot?.weekly ||
-      snapshot?.windows.find((w) => w.name === "weekly") ||
-      null,
+      snapshot?.weekly && isOrdinaryWindow(snapshot.weekly)
+        ? snapshot.weekly
+        : snapshot?.windows.find(
+            (window) =>
+              isOrdinaryWindow(window) && window.name === "weekly",
+          ) || null,
     planLabel: snapshot?.planLabel || snapshot?.planType || "Plus",
     resetLabel:
       resets.available == null ? "重置—" : `重置${resets.available}次`,
@@ -55,6 +75,7 @@ function modelFor(result: UsageResult): Model {
     live: result.ok,
     detail: result.ok ? "" : result.error.message,
     hasResetCredits: snapshot?.resetCreditsAvailable != null,
+    additionalText: additionalQuotaText(snapshot),
   };
 }
 function isSmall(family: string): boolean {
@@ -101,6 +122,7 @@ export function OverviewWidgetView({ result, family }: Props) {
           resetText: formatResetDate(model.weekly?.resetAt),
         }}
         fetchedText={model.fetched}
+        additionalText={model.additionalText || undefined}
       />
     );
 
@@ -132,6 +154,7 @@ export function OverviewWidgetView({ result, family }: Props) {
           ? { label: model.resetLabel, value: model.resetExpiration }
           : null
       }
+      additionalText={model.additionalText || undefined}
       errorText={!model.live && model.detail ? model.detail : undefined}
     />
   );


### PR DESCRIPTION
概要
从 origin/upstream 开发，移植 Codex provider 的三项修复，保留 upstream 的 provider contract 与 widget 架构。

缺陷与修法
附加额度进度条标签/去重错误

根因：附加窗口没有来源前缀，并按 (name, resetAtMs, usedPercent) 跨来源全局去重。
修法：以 metered_feature 生成稳定的 extra:<feature> ID；附加窗口带限额来源标签；去重限制在同一来源，并让 ordinary 窗口稳定排在前面；normalize 层保留附加窗口标签。
Codex Spark 额度未适配

根因：Spark 附加窗口按普通 five_hour/weekly 名称被选入主额度字段，widget 也只渲染主窗口。
修法：识别 limit_name/metered_feature 中的 Spark；主快照字段与 focus 仅接受 codex:/direct: 窗口；两个 Codex widget 保持主额度正确，同时显示附加额度摘要。
订阅等级识别与徽章键不匹配

根因：usage 响应缺少 plan_type 时没有从 JWT 回退；Pro/Pro Lite 标签无法命中 pro-20x/pro-5x 徽章配方。
修法：按 id_token → access_token 解析 https://api.openai.com/auth.chatgpt_plan_type；补齐 plan 映射，prolite → Pro 5X，pro/chatgptpro/chatgpt_pro → Pro 20X，并保留 enterprise/education 等映射。
验证
Codex 纯逻辑回归探针：PASS（窗口来源隔离、Spark 标签/ID、focus 过滤、JWT 优先级、Pro 映射）。
git show main:tools/check-syntax.js | npx --yes -p typescript@5 node - 'AI Usage'：145 files parsed, 0 syntax errors。
git diff --check：PASS。
开发目录 npx --yes -p typescript tsc --noEmit -p tsconfig.json：存在仓库既有的运行时全局/声明噪音及其他项目错误，未发现本次改动专属的新错误；详见工作会话记录。
风险/后续
本地开发目录当前是另一套 main 线布局（与 upstream 的 shared widget 架构不一一对应），为避免覆盖用户工作区，本 PR 未强行覆盖该目录；真机 widget 视觉仍需在 upstream 对应开发树中预览确认。