### PR TITLE
fix(ai-usage): MiniMax badge/档位与 Z.ai 窗口解析加固

### DIFF
--- a/AI Usage/providers/minimax/accounts.ts
+++ b/AI Usage/providers/minimax/accounts.ts
@@ -1,9 +1,15 @@
 import { createAccountStore } from "../../services/account-store";
+import { parseJwtPayload } from "../../services/jwt-payload";
 import type {
   AccountRegistry,
   MinimaxAccountProfile,
   MinimaxRegion,
 } from "./types";
+
+function jwtEmail(token: string | null): string | null {
+  const value = parseJwtPayload(token)?.email;
+  return typeof value === "string" && value.includes("@") ? value : null;
+}
 
 const store = createAccountStore<MinimaxAccountProfile>({
   registryKey: "ai_usage_minimax_account_registry_v1",
@@ -16,6 +22,22 @@ const store = createAccountStore<MinimaxAccountProfile>({
     createdAt: now,
     updatedAt: now,
   }),
+  migrate: (registry, { getSecret }) => {
+    let changed = false;
+    const accounts = registry.accounts.map((account) => {
+      if (account.email) return account;
+      const email = jwtEmail(getSecret(account.id, "access_token"));
+      if (!email) return account;
+      changed = true;
+      return {
+        ...account,
+        email,
+        name: email,
+        updatedAt: new Date().toISOString(),
+      };
+    });
+    return changed ? { ...registry, accounts } : registry;
+  },
 });
 
 export function ensureAccountMigration(): AccountRegistry {

--- a/AI Usage/providers/minimax/api.ts
+++ b/AI Usage/providers/minimax/api.ts
@@ -5,10 +5,18 @@ import {
   resolveProfile,
   saveProfileCredentials,
 } from "./accounts";
-import { formatPlanLabel, inferPlanFromLimit } from "./format";
+import {
+  buildPlanDisplayLabel,
+  inferPlanFromLimit,
+  sanitizeCachedPlanType,
+} from "./format";
 import { minimaxRequestHeaders, refreshOAuthToken } from "./oauth";
-import { quotaUrls, regionProbeOrder } from "./regions";
-import { hasMinimaxQuotaRows, parseMinimaxQuota } from "./usage-parser";
+import { planInfoUrls, quotaUrls, regionProbeOrder } from "./regions";
+import {
+  hasMinimaxQuotaRows,
+  parseMinimaxPlanPayload,
+  parseMinimaxQuota,
+} from "./usage-parser";
 import { createUsageCache } from "../../services/usage-cache";
 import type { MinimaxRegion, UsageResult, UsageSnapshot } from "./types";
 
@@ -21,12 +29,49 @@ const usageCache = createUsageCache<UsageSnapshot>({
   recentMs: MIN_LIVE_INTERVAL_MS,
 });
 
+/** 读取时清洗旧缓存：planType 只保留 raw，planLabel 由 raw 重建。 */
+function sanitizeSnapshot(
+  snapshot: UsageSnapshot | null,
+): UsageSnapshot | null {
+  if (!snapshot) return null;
+  const region = snapshot.region === "cn" || snapshot.region === "intl"
+    ? snapshot.region
+    : null;
+  const rawPlanType =
+    sanitizeCachedPlanType(snapshot.planType) ||
+    sanitizeCachedPlanType(snapshot.planLabel);
+  if (!region) {
+    return {
+      ...snapshot,
+      planType: rawPlanType,
+      planLabel: rawPlanType || snapshot.planLabel,
+    };
+  }
+  return {
+    ...snapshot,
+    planType: rawPlanType,
+    planLabel: buildPlanDisplayLabel(rawPlanType, region),
+  };
+}
+
 function readCache(profileId?: string | null): UsageSnapshot | null {
-  return usageCache.read(profileId);
+  const cached = usageCache.read(profileId);
+  const sanitized = sanitizeSnapshot(cached);
+  const id = resolveProfile(profileId)?.id;
+  if (
+    id &&
+    cached &&
+    sanitized &&
+    (cached.planType !== sanitized.planType ||
+      cached.planLabel !== sanitized.planLabel)
+  ) {
+    usageCache.write(id, sanitized);
+  }
+  return sanitized;
 }
 
 function writeCache(profileId: string, value: UsageSnapshot): void {
-  usageCache.write(profileId, value);
+  usageCache.write(profileId, sanitizeSnapshot(value) || value);
 }
 
 export const getCachedUsage = readCache;
@@ -39,7 +84,16 @@ function recoverRecentCache(
   profileId: string,
   force: boolean,
 ): UsageResult | null {
-  return usageCache.recoverRecent(profileId, force) as UsageResult | null;
+  const recovered = usageCache.recoverRecent(profileId, force) as UsageResult | null;
+  if (!recovered) return null;
+  if (recovered.ok) {
+    const snapshot = sanitizeSnapshot(recovered.snapshot);
+    return snapshot ? { ok: true, snapshot } : recovered;
+  }
+  return {
+    ...recovered,
+    cache: sanitizeSnapshot(recovered.cache || null),
+  };
 }
 
 type QuotaRequestResult =
@@ -74,6 +128,33 @@ async function requestQuota(
     }
   }
   return { ok: false, status: lastStatus };
+}
+
+/** 独立套餐接口拉取真实档位（对齐 zai/kimi 的 fetchPlanLabel）。 */
+async function fetchPlanLabel(
+  token: string,
+  region: MinimaxRegion,
+): Promise<string | null> {
+  for (const url of planInfoUrls(region)) {
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: minimaxRequestHeaders(token),
+        timeout: 15,
+        debugLabel:
+          region === "intl" ? "MinimaxPlanInfoIntl" : "MinimaxPlanInfoCn",
+      });
+      if (response.status === 401 || response.status === 403) continue;
+      if (!response.ok) continue;
+      const text = await response.text();
+      if (!text.trim() || text.trim().startsWith("<")) continue;
+      const plan = parseMinimaxPlanPayload(JSON.parse(text));
+      if (plan) return plan;
+    } catch {
+      /* try next URL */
+    }
+  }
+  return null;
 }
 
 export async function fetchUsage(options?: {
@@ -154,22 +235,22 @@ export async function fetchUsage(options?: {
     if (getProfileRegion(profile.id) !== region) {
       saveProfileCredentials(profile.id, { accessToken: token, region });
     }
-    const planLabel =
-      parsed.planLabel ||
+
+    // planType 只存原始档位；回退链绝不用带站点后缀的 planLabel（对齐 zai/kimi）。
+    const planType =
+      (await fetchPlanLabel(token, region)) ||
+      parsed.planType ||
       inferPlanFromLimit(parsed.intervalTotal, region) ||
-      cache?.planLabel ||
-      cache?.planType ||
+      sanitizeCachedPlanType(cache?.planType) ||
       null;
+
     const snapshot: UsageSnapshot = {
       windows: parsed.windows,
       fiveHour: parsed.fiveHour,
       weekly: parsed.weekly,
-      planType: planLabel,
-      planLabel: planLabel
-        ? `${formatPlanLabel(planLabel)} · ${region === "cn" ? "国内站" : "国际站"}`
-        : region === "cn"
-          ? "国内站"
-          : "国际站",
+      planType,
+      // MiniMax 需要区分站点，展示串在此层拼接一次；下次回退只用 planType。
+      planLabel: buildPlanDisplayLabel(planType, region),
       region,
       fetchedAt: new Date().toISOString(),
       source: "live",

--- a/AI Usage/providers/minimax/badge.ts
+++ b/AI Usage/providers/minimax/badge.ts
@@ -1,13 +1,10 @@
 import type { PlanBadgeRecipe } from "../badge-contract";
 import { linear } from "../badge-contract";
+import { stripRegionSuffixes } from "./format";
 
 export function resolveMinimaxBadge(label: string): PlanBadgeRecipe {
   return {
-    text:
-      label
-        .replace(/\s*[·•]\s*(国内站|国际站)$/i, "")
-        .trim()
-        .toUpperCase() || "MINIMAX",
+    text: stripRegionSuffixes(label).toUpperCase() || "MINIMAX",
     background: linear(["#9A3412", "#E85D04", "#F97316"]),
     foreground: "#FFFFFF",
   };

--- a/AI Usage/providers/minimax/format.ts
+++ b/AI Usage/providers/minimax/format.ts
@@ -1,10 +1,19 @@
+const REGION_SUFFIX_RE = /\s*[·•]\s*(国内站|国际站)/gi;
+
+/** 清除所有「· 国内站/国际站」后缀（含重复叠加）。 */
+export function stripRegionSuffixes(value: string): string {
+  return value.replace(REGION_SUFFIX_RE, "").trim();
+}
+
 function normalizePlanKey(value: string): string {
-  return value
-    .trim()
+  return stripRegionSuffixes(value)
     .replace(/coding\s*plan\s*/i, "")
     .replace(/token\s*plan\s*/i, "")
+    .replace(/code\s*plan\s*/i, "")
     .replace(/minimax\s*/i, "")
+    .replace(/high\s*speed/i, "")
     .replace(/[\s_]+/g, "-")
+    .replace(/^-+|-+$/g, "")
     .toLowerCase();
 }
 
@@ -15,12 +24,29 @@ function titleCaseWords(value: string): string {
     .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+/**
+ * 将缓存中可能已污染的展示标签还原为原始档位。
+ * 只返回适合再次喂入 formatPlanLabel 的 raw 值。
+ */
+export function sanitizeCachedPlanType(
+  value: string | null | undefined,
+): string | null {
+  if (!value || !value.trim()) return null;
+  const stripped = stripRegionSuffixes(value);
+  if (!stripped) return null;
+  // 已是纯区域名，不是档位
+  if (/^(国内站|国际站)$/i.test(stripped)) return null;
+  return formatPlanLabel(stripped) || stripped;
+}
+
 /** MiniMax Coding / Token Plan 套餐档位 */
 export function formatPlanLabel(
   value: string | null | undefined,
 ): string | null {
   if (!value || !value.trim()) return null;
-  const normalized = normalizePlanKey(value);
+  const cleaned = stripRegionSuffixes(value);
+  if (!cleaned || /^(国内站|国际站)$/i.test(cleaned)) return null;
+  const normalized = normalizePlanKey(cleaned);
   const labels: { [key: string]: string } = {
     free: "Free",
     starter: "Starter",
@@ -28,12 +54,56 @@ export function formatPlanLabel(
     pro: "Pro",
     max: "Max",
     ultra: "Ultra",
+    trial: "Trial",
+    "new-ultra": "Ultra",
+    "token-plan-credit": "Credit",
+    "token-plan-credit-team": "Credit Team",
   };
   if (labels[normalized]) return labels[normalized];
-  const match = value.match(/\b(Free|Starter|Plus|Pro|Max|Ultra)\b/i);
+  const match = cleaned.match(/\b(Free|Starter|Plus|Pro|Max|Ultra|Trial)\b/i);
   if (match)
     return match[1].charAt(0).toUpperCase() + match[1].slice(1).toLowerCase();
-  return titleCaseWords(value.trim());
+  return titleCaseWords(cleaned);
+}
+
+/** 控制台 combo / package 枚举 → 展示档位 */
+export function planTypeFromComboId(
+  value: number | string | null | undefined,
+): string | null {
+  if (value == null || value === "") return null;
+  const id = typeof value === "number" ? value : Number(String(value).trim());
+  if (!Number.isFinite(id)) return null;
+  const map: { [key: number]: string } = {
+    0: "Free",
+    2: "Starter",
+    3: "Standard",
+    24: "Starter",
+    25: "Plus",
+    26: "Max",
+    28: "Trial",
+    101001: "Starter",
+    101002: "Plus",
+    101003: "Max",
+    101004: "Ultra",
+    101005: "Ultra",
+  };
+  return map[id] || null;
+}
+
+export function regionDisplayName(
+  region: "intl" | "cn" | null | undefined,
+): string {
+  return region === "cn" ? "国内站" : "国际站";
+}
+
+/** 由 raw planType 生成一次性展示标签，绝不再吃回已带后缀的标签。 */
+export function buildPlanDisplayLabel(
+  planType: string | null | undefined,
+  region: "intl" | "cn",
+): string {
+  const formatted = formatPlanLabel(planType);
+  const regionLabel = regionDisplayName(region);
+  return formatted ? `${formatted} · ${regionLabel}` : regionLabel;
 }
 
 /**

--- a/AI Usage/providers/minimax/oauth.ts
+++ b/AI Usage/providers/minimax/oauth.ts
@@ -1,12 +1,14 @@
 import { activePendingAuthorization } from "../../services/oauth-pending";
 import { fetch } from "scripting";
+import { parseJwtPayload } from "../../services/jwt-payload";
 import {
   getProfileAccessToken,
   getProfileRegion,
   saveProfileCredentials,
 } from "./accounts";
+import { regionDisplayName } from "./format";
 import { chooseMinimaxRegion } from "./region-selection";
-import { consoleUrlForRegion, quotaUrls } from "./regions";
+import { consoleUrlForRegion, quotaUrls, userInfoUrls } from "./regions";
 import type { MinimaxRegion } from "./types";
 
 const PENDING_KEY = "ai_usage_minimax_oauth_pending_v1";
@@ -16,6 +18,12 @@ type PendingAuth = {
   createdAt: number;
   profileId: string;
   region: MinimaxRegion;
+};
+
+export type MinimaxIdentity = {
+  email: string | null;
+  accountId: string | null;
+  name: string | null;
 };
 
 function savePending(value: PendingAuth): void {
@@ -105,6 +113,130 @@ function normalizeApiKey(input: string): string {
   return trimmed;
 }
 
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function parseIdentityPayload(payload: unknown): MinimaxIdentity | null {
+  const object = asObject(payload);
+  if (!object) return null;
+  const base = asObject(object.base_resp);
+  const statusCode =
+    typeof base?.status_code === "number" ? base.status_code : null;
+  if (statusCode != null && statusCode !== 0) return null;
+
+  const data =
+    asObject(object.data) ||
+    asObject(object.user) ||
+    asObject(object.user_info) ||
+    asObject(object.biz_info) ||
+    object;
+
+  const email = firstString(
+    data.email,
+    data.mail,
+    data.user_email,
+    object.email,
+    object.mail,
+  );
+  const emailOk = email && email.includes("@") ? email : null;
+
+  const accountId = firstString(
+    data.user_id,
+    data.uid,
+    data.id,
+    data.account_id,
+    data.subject,
+    object.user_id,
+    object.uid,
+    object.account_id,
+  );
+
+  const org = firstString(
+    data.org_name,
+    data.organization_name,
+    data.organization,
+    data.group_name,
+    data.company_name,
+    data.team_name,
+  );
+  const nickname = firstString(
+    data.nickname,
+    data.nick_name,
+    data.user_name,
+    data.username,
+    data.name,
+    data.display_name,
+    object.nickname,
+    object.name,
+  );
+
+  const name = nickname || org || emailOk;
+  if (!emailOk && !accountId && !name) return null;
+  return { email: emailOk, accountId, name };
+}
+
+function identityFromJwt(token: string): MinimaxIdentity | null {
+  const jwt = parseJwtPayload(token);
+  if (!jwt) return null;
+  const emailRaw = firstString(jwt.email, jwt.mail, jwt.user_email);
+  const email =
+    emailRaw && emailRaw.includes("@") ? emailRaw : null;
+  const accountId = firstString(
+    jwt.sub,
+    jwt.user_id,
+    jwt.uid,
+    jwt.id,
+    jwt.account_id,
+  );
+  const name = firstString(
+    jwt.nickname,
+    jwt.name,
+    jwt.preferred_username,
+    jwt.username,
+  );
+  if (!email && !accountId && !name) return null;
+  return { email, accountId, name };
+}
+
+/** 登录完成后拉取用户信息（对齐 antigravity fetchUserInfo / claude JWT）。 */
+export async function fetchUserInfo(
+  token: string,
+  region: MinimaxRegion,
+): Promise<MinimaxIdentity> {
+  for (const url of userInfoUrls(region)) {
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: minimaxRequestHeaders(token),
+        timeout: 15,
+        debugLabel:
+          region === "intl" ? "MinimaxUserInfoIntl" : "MinimaxUserInfoCn",
+      });
+      if (response.status === 401 || response.status === 403) continue;
+      if (!response.ok) continue;
+      const text = await response.text();
+      if (!text.trim() || text.trim().startsWith("<")) continue;
+      const identity = parseIdentityPayload(JSON.parse(text));
+      if (identity) return identity;
+    } catch {
+      /* try next endpoint */
+    }
+  }
+  return (
+    identityFromJwt(token) || { email: null, accountId: null, name: null }
+  );
+}
+
 async function probeRegionPayload(
   apiKey: string,
   region: MinimaxRegion,
@@ -149,14 +281,14 @@ export async function completeMinimaxLogin(input?: string): Promise<void> {
       );
 
     const masked = `${apiKey.slice(0, 4)}…${apiKey.slice(-4)}`;
+    const fallbackName = `MiniMax ${regionDisplayName(region)} ${masked}`;
+    const identity = await fetchUserInfo(apiKey, region);
     const saved = saveProfileCredentials(pending.profileId, {
       accessToken: apiKey,
       region,
-      name:
-        region === "cn"
-          ? `MiniMax 国内站 ${masked}`
-          : `MiniMax 国际站 ${masked}`,
-      accountId: masked,
+      name: identity.name || identity.email || fallbackName,
+      email: identity.email,
+      accountId: identity.accountId || masked,
     });
     if (!saved)
       throw new Error("Subscription Key 已验证，但本机 Keychain 保存失败");

--- a/AI Usage/providers/minimax/regions.ts
+++ b/AI Usage/providers/minimax/regions.ts
@@ -20,12 +20,52 @@ const QUOTA_URLS: Record<MinimaxRegion, string[]> = {
   ],
 };
 
+/** Subscription Key 可查询的套餐信息（控制台 remains_percent 接受 API Key）。 */
+const PLAN_INFO_URLS: Record<MinimaxRegion, string[]> = {
+  intl: [
+    "https://api.minimax.io/backend/account/token_plan/remains_percent",
+    "https://www.minimax.io/backend/account/token_plan/remains_percent",
+    "https://platform.minimax.io/backend/account/token_plan/remains_percent",
+  ],
+  cn: [
+    "https://api.minimaxi.com/backend/account/token_plan/remains_percent",
+    "https://www.minimaxi.com/backend/account/token_plan/remains_percent",
+    "https://platform.minimaxi.com/backend/account/token_plan/remains_percent",
+  ],
+};
+
+/** 用户信息：Subscription Key / 会话均可尝试；拿不到时由调用方兜底。 */
+const USER_INFO_URLS: Record<MinimaxRegion, string[]> = {
+  intl: [
+    "https://www.minimax.io/v1/api/user/info",
+    "https://api.minimax.io/v1/api/user/info",
+    "https://www.minimax.io/backend/user/biz_info",
+    "https://platform.minimax.io/backend/user/biz_info",
+    "https://api.minimax.io/backend/user/biz_info",
+  ],
+  cn: [
+    "https://www.minimaxi.com/v1/api/user/info",
+    "https://api.minimaxi.com/v1/api/user/info",
+    "https://www.minimaxi.com/backend/user/biz_info",
+    "https://platform.minimaxi.com/backend/user/biz_info",
+    "https://api.minimaxi.com/backend/user/biz_info",
+  ],
+};
+
 export function consoleUrlForRegion(region: MinimaxRegion): string {
   return CONSOLE_URLS[region];
 }
 
 export function quotaUrls(region: MinimaxRegion): string[] {
   return [...QUOTA_URLS[region]];
+}
+
+export function planInfoUrls(region: MinimaxRegion): string[] {
+  return [...PLAN_INFO_URLS[region]];
+}
+
+export function userInfoUrls(region: MinimaxRegion): string[] {
+  return [...USER_INFO_URLS[region]];
 }
 
 export function regionProbeOrder(

--- a/AI Usage/providers/minimax/usage-parser.ts
+++ b/AI Usage/providers/minimax/usage-parser.ts
@@ -1,4 +1,8 @@
-import { formatPlanLabel } from "./format";
+import {
+  formatPlanLabel,
+  planTypeFromComboId,
+  sanitizeCachedPlanType,
+} from "./format";
 import type { LimitWindow, MinimaxRegion } from "./types";
 
 const MINIMAX_WINDOW = {
@@ -10,7 +14,8 @@ export type ParsedMinimaxQuota = {
   windows: LimitWindow[];
   fiveHour: LimitWindow | null;
   weekly: LimitWindow | null;
-  planLabel: string | null;
+  /** 原始档位（不含区域后缀），可供缓存回退 */
+  planType: string | null;
   intervalTotal: number | null;
 };
 
@@ -33,6 +38,13 @@ function toNumber(value: unknown): number | null {
 
 function clamp(value: number): number {
   return Math.max(0, Math.min(100, value));
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
 }
 
 function quotaRows(payload: unknown): Record<string, unknown>[] {
@@ -142,6 +154,62 @@ function windowFromCounts(options: {
   };
 }
 
+function extractPlanType(
+  object: Record<string, unknown>,
+  row: Record<string, unknown> | null,
+): string | null {
+  const nested =
+    asObject(object.data) ||
+    asObject(object.subscription) ||
+    asObject(object.token_plan) ||
+    asObject(object.coding_plan) ||
+    asObject(row?.subscription) ||
+    null;
+  const comboId =
+    toNumber(row?.combo_id) ??
+    toNumber(row?.package_id) ??
+    toNumber(object.combo_id) ??
+    toNumber(object.package_id) ??
+    toNumber(nested?.combo_id) ??
+    toNumber(nested?.package_id);
+  const fromCombo = planTypeFromComboId(comboId);
+  if (fromCombo) return fromCombo;
+
+  const planRaw = firstString(
+    row?.current_subscribe_title,
+    row?.plan_name,
+    row?.plan,
+    row?.subscribe_title,
+    row?.package_name,
+    row?.product_name,
+    row?.combo_name,
+    object.current_subscribe_title,
+    object.plan_name,
+    object.plan,
+    object.subscribe_title,
+    object.package_name,
+    nested?.current_subscribe_title,
+    nested?.plan_name,
+    nested?.plan,
+    nested?.subscribe_title,
+    nested?.package_name,
+    nested?.title,
+  );
+  return sanitizeCachedPlanType(planRaw) || formatPlanLabel(planRaw);
+}
+
+/** 从 remains_percent / 套餐信息响应中解析档位。 */
+export function parseMinimaxPlanPayload(payload: unknown): string | null {
+  const object = asObject(payload);
+  if (!object) return null;
+  const base = asObject(object.base_resp);
+  const statusCode = toNumber(base?.status_code);
+  if (statusCode != null && statusCode !== 0) return null;
+  const data = asObject(object.data) || object;
+  const row = pickPrimaryRow(quotaRows(object)) || asObject(data);
+  return extractPlanType(object, row);
+}
+
 export function parseMinimaxQuota(
   payload: unknown,
   region: MinimaxRegion,
@@ -186,19 +254,11 @@ export function parseMinimaxQuota(
   if (fiveHour) windows.push(fiveHour);
   if (weekly) windows.push(weekly);
   if (!windows.length) return null;
-  const planRaw =
-    (typeof row.current_subscribe_title === "string" &&
-      row.current_subscribe_title) ||
-    (typeof row.plan_name === "string" && row.plan_name) ||
-    (typeof row.plan === "string" && row.plan) ||
-    (typeof object.current_subscribe_title === "string" &&
-      object.current_subscribe_title) ||
-    null;
   return {
     windows,
     fiveHour,
     weekly,
-    planLabel: formatPlanLabel(planRaw),
+    planType: extractPlanType(object, row),
     intervalTotal,
   };
 }

--- a/AI Usage/providers/zai/api.ts
+++ b/AI Usage/providers/zai/api.ts
@@ -135,7 +135,7 @@ export async function fetchUsage(options?: {
       preferred === "cn" ? ["cn", "intl"] : ["intl", "cn"];
     let payload: Record<string, unknown> | null = null;
     let region: ZaiRegion | null = null;
-    let lastStatus = 0;
+    const statuses: Partial<Record<ZaiRegion, number>> = {};
 
     for (const candidate of order) {
       const result = await requestQuota(token, candidate);
@@ -144,22 +144,34 @@ export async function fetchUsage(options?: {
         region = candidate;
         break;
       }
-      lastStatus = result.status;
-      if (result.status === 401 || result.status === 403) continue;
+      statuses[candidate] = result.status;
     }
 
     if (!payload || !region) {
       const recovered = recoverRecentCache(profile.id, Boolean(options?.force));
       if (recovered) return recovered;
-      const unauthorized = lastStatus === 401 || lastStatus === 403;
+      const isAuth = (status: number | undefined) =>
+        status === 401 || status === 403;
+      const preferredStatus = statuses[preferred];
+      const tried = order.filter((item) => statuses[item] != null);
+      const bothAuthFailed =
+        tried.length >= 2 && tried.every((item) => isAuth(statuses[item]));
+      // Only treat as bad key when the preferred region itself is 401/403,
+      // or every region we tried failed auth. A preferred 5xx + fallback 401
+      // must surface the preferred HTTP error, not "API Key 无效".
+      const unauthorized = isAuth(preferredStatus) || bothAuthFailed;
+      const reportStatus =
+        preferredStatus ??
+        statuses[order.find((item) => item !== preferred)!] ??
+        0;
       return {
         ok: false,
         error: {
           code: unauthorized ? "unauthorized" : "http_error",
           message: unauthorized
             ? "Z.ai API Key 无效或已过期，请重新配置"
-            : `Z.ai 用量请求失败（HTTP ${lastStatus || "?"}）`,
-          status: lastStatus || undefined,
+            : `Z.ai 用量请求失败（HTTP ${reportStatus || "?"}）`,
+          status: reportStatus || undefined,
         },
         cache: readCache(profile.id) || cache,
       };
@@ -188,6 +200,7 @@ export async function fetchUsage(options?: {
 
     const planLabel =
       (await fetchPlanLabel(token, region)) ||
+      parsed.planLabel ||
       cache?.planLabel ||
       cache?.planType ||
       null;

--- a/AI Usage/providers/zai/usage-parser.ts
+++ b/AI Usage/providers/zai/usage-parser.ts
@@ -1,3 +1,4 @@
+import { writeLog } from "../../services/logger";
 import type { LimitWindow, LimitWindowName } from "./types";
 
 export type ParsedZaiQuota = {
@@ -5,6 +6,30 @@ export type ParsedZaiQuota = {
   fiveHour: LimitWindow | null;
   weekly: LimitWindow | null;
   monthly: LimitWindow | null;
+  planLabel: string | null;
+};
+
+/** Slot anchors used for nearest-window classification (seconds). */
+const SLOT_SECONDS: Array<{
+  name: Exclude<LimitWindowName, "web_search" | "unknown">;
+  label: string;
+  seconds: number;
+}> = [
+  { name: "five_hour", label: "5 小时", seconds: 5 * 3600 },
+  { name: "weekly", label: "每周", seconds: 7 * 86400 },
+  { name: "monthly", label: "每月", seconds: 30 * 86400 },
+];
+
+/**
+ * Z.ai `unit` enum (undocumented; verified against CodexBar zai.js & tokn-provider-zai):
+ * 1 = day, 3 = hour, 5 = month, 6 = week.
+ * Note: older guesses treated unit 6 as "day"; live CREDIT_LIMIT weekly rows use (6, 1).
+ */
+const UNIT_SECONDS: Record<number, number> = {
+  1: 86400,
+  3: 3600,
+  5: 30 * 86400,
+  6: 7 * 86400,
 };
 
 function asObject(value: unknown): Record<string, unknown> | null {
@@ -38,17 +63,61 @@ function resetTime(value: unknown): { iso: string | null; ms: number | null } {
     : { iso: null, ms: null };
 }
 
+function logUnrecognized(message: string, code: string): void {
+  writeLog({
+    level: "warning",
+    source: "app",
+    category: "refresh",
+    event: "zai.quota.unrecognized",
+    provider: "zai",
+    message,
+    code,
+  });
+}
+
 function tokenWindowKind(
   unit: number | null,
   number: number | null,
+  type: string,
 ): { name: LimitWindowName; label: string; seconds: number } | null {
-  if (unit === 3 && number === 5)
-    return { name: "five_hour", label: "5 小时", seconds: 5 * 3600 };
-  if (unit === 6 && number === 7)
-    return { name: "weekly", label: "每周", seconds: 7 * 86400 };
-  if (unit === 5 && number === 1)
-    return { name: "monthly", label: "每月", seconds: 30 * 86400 };
-  return null;
+  if (unit == null || number == null || number <= 0) {
+    logUnrecognized(
+      `无法识别的额度窗口 type=${type} unit=${unit ?? "?"} number=${number ?? "?"}`,
+      "unrecognized_window",
+    );
+    return null;
+  }
+  const unitSeconds = UNIT_SECONDS[unit];
+  if (unitSeconds == null) {
+    logUnrecognized(
+      `未知 unit 编码 type=${type} unit=${unit} number=${number}`,
+      "unknown_unit",
+    );
+    return null;
+  }
+  // Modern API: unit=6 means week → (6,1)=1 week. Legacy docs listed (6,7) as
+  // a 7-day window; keep that pair on the weekly slot instead of 7 weeks.
+  const seconds =
+    unit === 6 && number === 7 ? 7 * 86400 : number * unitSeconds;
+  let best = SLOT_SECONDS[0];
+  let bestDelta = Math.abs(seconds - best.seconds);
+  for (let i = 1; i < SLOT_SECONDS.length; i++) {
+    const slot = SLOT_SECONDS[i];
+    const delta = Math.abs(seconds - slot.seconds);
+    if (delta < bestDelta) {
+      best = slot;
+      bestDelta = delta;
+    }
+  }
+  return { name: best.name, label: best.label, seconds };
+}
+
+function timeLimitLabel(item: Record<string, unknown>): string {
+  for (const key of ["name", "limitName", "description", "label", "title"]) {
+    const value = item[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "Web Search";
 }
 
 function limitWindow(
@@ -58,17 +127,26 @@ function limitWindow(
   const type = String(item.type || "").toUpperCase();
   const percentage = toNumber(item.percentage);
   if (percentage == null) return null;
-  const kind =
-    type === "TOKENS_LIMIT"
-      ? tokenWindowKind(toNumber(item.unit), toNumber(item.number))
-      : type === "TIME_LIMIT"
-        ? {
-            name: "web_search" as const,
-            label: "Web Search",
-            seconds: 30 * 86400,
-          }
-        : null;
+
+  let kind: { name: LimitWindowName; label: string; seconds: number } | null =
+    null;
+  if (type === "TOKENS_LIMIT" || type === "CREDIT_LIMIT") {
+    kind = tokenWindowKind(toNumber(item.unit), toNumber(item.number), type);
+  } else if (type === "TIME_LIMIT") {
+    kind = {
+      name: "web_search",
+      label: timeLimitLabel(item),
+      seconds: 30 * 86400,
+    };
+  } else {
+    logUnrecognized(
+      `未处理的额度类型 type=${type || "?"} unit=${item.unit ?? "?"} number=${item.number ?? "?"}`,
+      "unknown_limit_type",
+    );
+    return null;
+  }
   if (!kind) return null;
+
   const usedPercent = clamp(percentage);
   const reset = resetTime(item.nextResetTime);
   return {
@@ -91,6 +169,19 @@ const WINDOW_RANK: Record<LimitWindowName, number> = {
   unknown: 4,
 };
 
+function extractPlanFromQuotaData(
+  data: Record<string, unknown> | null,
+): string | null {
+  if (!data) return null;
+  for (const key of ["planName", "plan", "plan_type", "packageName", "level"]) {
+    const value = data[key];
+    if (typeof value === "string" && value.trim()) {
+      return formatZaiPlanLabel(value);
+    }
+  }
+  return null;
+}
+
 export function parseZaiQuota(payload: unknown): ParsedZaiQuota | null {
   const root = asObject(payload);
   const data = asObject(root?.data);
@@ -112,6 +203,7 @@ export function parseZaiQuota(payload: unknown): ParsedZaiQuota | null {
     fiveHour: byName("five_hour"),
     weekly: byName("weekly"),
     monthly: byName("monthly"),
+    planLabel: extractPlanFromQuotaData(data),
   };
 }
 
@@ -153,15 +245,32 @@ export function formatZaiPlanLabel(
   return titleCaseWords(value.trim());
 }
 
+function purchaseTimeMs(record: Record<string, unknown>): number {
+  const raw = record.purchaseTime ?? record.purchase_time;
+  if (typeof raw === "string" && raw.trim()) {
+    const parsed = Date.parse(raw);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  const numeric = toNumber(raw);
+  if (numeric == null || numeric <= 0) return 0;
+  return numeric < 1e12 ? numeric * 1000 : numeric;
+}
+
 export function parseZaiSubscription(payload: unknown): string | null {
   const root = asObject(payload);
   const list = Array.isArray(root?.data) ? root.data : [];
+  const candidates: Array<{
+    label: string;
+    inCurrent: boolean;
+    purchaseTime: number;
+  }> = [];
+
   for (const item of list) {
     const record = asObject(item);
     if (!record) continue;
     const status = String(record.status || "").toUpperCase();
-    if (status && status !== "VALID" && record.inCurrentPeriod !== true)
-      continue;
+    const inCurrent = record.inCurrentPeriod === true;
+    if (status && status !== "VALID" && !inCurrent) continue;
     const name =
       typeof record.productName === "string"
         ? record.productName
@@ -169,7 +278,18 @@ export function parseZaiSubscription(payload: unknown): string | null {
           ? record.product_name
           : null;
     const label = formatZaiPlanLabel(name);
-    if (label) return label;
+    if (!label) continue;
+    candidates.push({
+      label,
+      inCurrent,
+      purchaseTime: purchaseTimeMs(record),
+    });
   }
-  return null;
+
+  if (!candidates.length) return null;
+  candidates.sort((left, right) => {
+    if (left.inCurrent !== right.inCurrent) return left.inCurrent ? -1 : 1;
+    return right.purchaseTime - left.purchaseTime;
+  });
+  return candidates[0].label;
 }


### PR DESCRIPTION
## MiniMax

- 修复 badge「· 国内站/国际站」后缀无限叠加：统一用 `stripRegionSuffixes` 清除重复后缀，并在 `planType`（原始档位）与 `planLabel`（一次性展示标签）之间严格分离，避免展示串被再次拼进缓存。
- 接入订阅档位与用户信息：支持 combo/package 枚举映射、独立套餐接口拉取、JWT/控制台用户信息回填，以及区域探测与展示标签重建。

## Z.ai

- 额度窗口解析改为通用 unit→秒换算 + 最近槽位匹配（不再依赖脆弱白名单），并支持 `CREDIT_LIMIT`。
- `TIME_LIMIT` 使用接口返回的 label（兜底 Web Search）；配额数据与多订阅列表均可作为套餐兜底；多订阅按当前周期优先、购买时间次之选取。
- 双区域探测失败时的错误归类：仅当首选区域本身 401/403，或两侧均鉴权失败时标记 `unauthorized`，避免首选 5xx + 备用 401 被误报为「API Key 无效」。

---

上述改动已在 fork（gamesme/scripting）内经 PR #37 / #38 审核并合并到 `upstream` 分支；本 PR 基于上游 `main`（含账号持久化与 widget 自动刷新加固）重新 cherry-pick，冲突处保留双方修复意图。